### PR TITLE
Pass `0` to the `RuntimeException` constructor

### DIFF
--- a/lib/OnlinePayments/Sdk/Webhooks/SignatureValidationException.php
+++ b/lib/OnlinePayments/Sdk/Webhooks/SignatureValidationException.php
@@ -18,6 +18,6 @@ class SignatureValidationException extends RuntimeException
      */
     public function __construct($message = null, $previous = null)
     {
-        parent::__construct($message, null, $previous);
+        parent::__construct($message, 0, $previous);
     }
 }


### PR DESCRIPTION
Pass `0` instead of `null` to the `RuntimeException` constructor. Passing `null` is deprecated in newer PHP versions: https://3v4l.org/igBTO